### PR TITLE
Updated article

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,102 +1,70 @@
 # dotcms-htmx
-A tutorial to integrate htmx into DotCMS demo site's search page.
 
-## Overview
-DotCMS, in addition to its extensive APIs and headless features, is also a great platform to manage rich websites with server-generated HTML pages.
+A tutorial to integrate htmx into dotCMS demo site's search page.
 
-Htmx is a library that allows you to access modern browser features directly from HTML, rather than using javascript.
+## Overview {#Overview}
 
-Combining dotCMS and htmx allows web developers to incorporate responsive, ajax-style elements and features to server-generated HTML pages without 
+dotCMS, in addition to its extensive APIs and headless features, is also a great platform to manage rich websites with server-generated HTML pages.
 
+[Htmx](https://htmx.org/) is a library that allows you to access modern browser features directly from HTML, rather than using Javascript. For some common website features built with htmx, see the following two examples:
 
-See the [htmx Active Search](https://htmx.org/examples/active-search/) example - slowly type a name in the demo at the bottom of the page.
+- [htmx Active Search](https://htmx.org/examples/active-search/) example — slowly type a name in the demo at the bottom of the page.
+- [htmx Infinite Scroll](https://htmx.org/examples/infinite-scroll/) works through an attribute applied to a final item in a list, and then likewise applied to the final item of each list segment the server appends.
 
-https://htmx.org/examples/infinite-scroll/
+Combining dotCMS and htmx allows web developers to incorporate responsive, AJAX-style elements and features to server-generated HTML pages with a minimum of composed Javascript — which is to say, in some estimations, a minimum of fuss.
 
-Use two browser windows - one logged into the DotCMS admin/back-end, and another browser not logged in to emulate site visitors.
+This article will guide you through the basic setup of an htmx-enabled dotCMS instance from scratch.
 
-## Running DotCMS with demo site content
+## Running dotCMS With Demo Site Content {#RunningDotCMSDemo}
 
-DotCMS provides a "demo" site to allow you to test and explore DotCMS features. Run DotCMS demo site locally using the `single-node-demo-site` from our [docker compose examples](https://github.com/dotCMS/core/tree/master/docker/docker-compose-examples)
+dotCMS provides a Demo site to allow you to test and explore dotCMS features.
 
-### Run DotCMS from Docker
-On current OS X:
+### Run dotCMS from Docker {#RunDotCMS}
 
-Install and run [Docker Desktop](https://www.docker.com/products/docker-desktop)
+> Below are a summarized set of steps, but you can also follow the instructions on our [Quick-Start Guide](/docs/latest/quick-start-guide).
 
-In Docker Desktop -> Preferences -> Resources -> Advanced -> increase Memory to at least 6G
+- Install and run [Docker Desktop](https://www.docker.com/products/docker-desktop).
+- In **Docker Desktop -> Preferences -> Resources -> Advanced**, you may wish to increase the allocated memory to improve performance. Generally **6 GB** is considered a good all-purpose amount of headroom, but depending on implementation and needs, you may be able to run comfortably on 4 or fewer.
 
-Open `Terminal` application and run:
+To run the dotCMS demo site locally, use the `single-node-demo-site` from our [Docker Compose examples](https://github.com/dotCMS/core/tree/master/docker/docker-compose-examples):
+
+Open your command-line application (Terminal on macOS or Command Prompt on Windows) and run:
+
 ```sh
 curl -o docker-compose.yml https://raw.githubusercontent.com/dotCMS/core/master/docker/docker-compose-examples/single-node-demo-site/docker-compose.yml
 docker compose up -d 
 docker ps
 ```
-You should see docker containers for DotCMS, Postgres, and Elasticsearch.
 
-### Open browsers to DotCMS front-end and back-end 
-DotCMS app is listening on two ports - either is fine, we'll use 8080.
+> (Note: Windows 10 & 11 both come with the `curl` command preinstalled. However, if you're using Windows 7 or 8, you'll need to [install it](https://curl.se/)).)
 
-`http:  8080`
+You should see the software create Docker containers for dotCMS, Postgres, and Elasticsearch. The process may take a few minutes to complete. 
 
-`https: 8443` - you must accept the SSL cert 
+### Open dotCMS Front and Back Ends {#FrontEndBackEnd}
 
-Open a broweser and log in to DotCMS back-end:
+To most easily observe changes in real time, use two browser windows that do not share session data — either separate browsers or one normal and one Private/Incognito window. Sign in with one; leave the other signed out, to emulate a normal site visitor.
 
-[http://localhost:8080/dotAdmin/](http://localhost:8080/dotAdmin/) 
+The dotCMS application is listening on two ports by default:
+- HTTP: `8082`
+- HTTPS: `8443` (you must accept the SSL certificate)
 
-```
-username: admin@dotcms.com
-password: admin
-```
+Either is fine, but we'll use `8082`. Sign in with the following link: [http://localhost:8082/dotAdmin/](http://localhost:8082/dotAdmin/) 
 
-Open a different browser or incognito window and browse to the Search page (you won't see any search results until you create a Site Search index).
+- username: `admin@dotcms.com`
+- password: `admin`
 
-[http://localhost:8080/search/](http://localhost:8080/search/) 
+> Note: At the time of writing, the YAML file includes a `DOT_INITIAL_ADMIN_PASSWORD` environment variable, set to the value `admin`. If this is absent, then the default admin password will instead be a randomly generated string that can be found in the server's startup logs. See the [Quick Start Guide](/docs/latest/quick-start-guide) for more information.
 
- A version of the demo site is always publically available at [https://demo.dotcms.com](https://demo.dotcms.com) but it is recreated multiple times/day so your changes will not persist and can be changed by others using the site.
+A version of the demo site is always publically available at [https://demo.dotcms.com](https://demo.dotcms.com) but it is recreated multiple times/day so your changes will not persist and can be changed by others using the site.
 
-## Create dotCMS Site Search Index
-[DotCMS Site Search Docs](https://dotcms.com/docs/latest/site-search)
+## Load Htmx Javascript in the Theme Footer {#LoadHtmx}
 
-DotCMS requires a Site Search index to support searches from front-end sites. 
+> For the official instructions, see the [htmx installation documentation](https://htmx.org/docs/#installing).
 
-Create a Site Search index in the back-end:
+In the back end, go to: **Site -> Browser -> application -> themes -> travel**
 
-`Dev Tools -> Site Search -> Job Scheduler -> create a job:`
-```
-Run: Now
-Select Sites to Index: Index All Sites
-Alias Name: default
-Language: English, Espanol
-```
-Click EXECUTE 
+Double-click `footer.vtl` — scroll to the bottom of file editor and add htmx to the Javascript section:
 
-The "View All Jobs" tab shows the progress. It should take only a couple minutes for dotCMS to crawl the front-end pages and create an index.
-
-Once complete, the "Indices" tab should show a healthy index.
-
-### Note the query strings used by static search page
-In the front-end browser, search for "ski" at [http://localhost:8080/search/](http://localhost:8080/search/) 
-
-You should see search results. Note the uri for the first page of results:
-
-`/search/index?q=ski&search=Search`
-
-Scroll down and click **2** for the next page of results and note the uri adds `&p=[page_number]` for the pages (which are zero-indexed):
-
-`/search/index?q=ski&p=1`
-
-[http://localhost:8080/search/index?q=ski&p=1](http://localhost:8080/search/index?q=ski&p=1) 
-
-## Load htmx javascript in the Theme footer
-["Installing htmx" docs](https://htmx.org/docs/#installing)
-
-In the back-end go to:
-
-`Site -> Browser -> application -> themes -> travel`
-
-Double-click `footer.vtl` - scroll to the bottom of file editor and add htmx to the Javascript section:
 ```html
 <!-- Javascript-->
 <script src="${dotTheme.path}js/core.min.js"></script>
@@ -104,130 +72,162 @@ Double-click `footer.vtl` - scroll to the bottom of file editor and add htmx to 
 <script src="https://unpkg.com/htmx.org@1.7.0"></script>
 #end
 ```
-click Publish
 
-On the front-end site,  reload and "view source" on the [/search/](http://localhost:8080/search/) page to confirm htmx is included in the footer.
+Click `Publish`.
 
-## Simplify VTL in the static /search/ page
+On the front-end site, reload and "view source" on the [/search/](http://localhost:8082/search/) page to confirm htmx is included in the footer.
+
+Just like that, **we're up and running with htmx**!
+
+But before we call our work finished, **let's build something with it** over the following sections. We'll be interacting with dotCMS's search functionality, so the first order of business is to build an index.
+
+## Create dotCMS Site Search Index {#CreateSearchIndex}
+
+Open a different browser or incognito window and browse to the Search page: [http://localhost:8082/search/](http://localhost:8082/search/)
+
+As you'll see, the search function is operational, but you won't see any results until you create a Site Search index; dotCMS requires an index to support searches from front-end sites.
+
+To create a Site Search index in the back end, navigate to **Dev Tools -> Site Search -> Job Scheduler**. Next, create a job with the following parameters:
+
+- Run: `Now`
+- Select Sites to Index: Select `Index All Sites` checkbox
+- Alias Name: `default`
+- Language: `English, Espanol`
+
+Finally, click `EXECUTE`.
+
+The "View All Jobs" tab shows your progress. It should take only a couple minutes for dotCMS to crawl the front-end pages and create an index.
+
+Once complete, the "Indices" tab should show a healthy index.
+
+> For more general info about search functionality, see the [dotCMS Site Search Docs](https://dotcms.com/docs/latest/site-search).
+
+### Note the Query Strings Used by the Search Page {#QueryStringsQuery}
+
+Once the index is in place, [returning to the front-end search page](http://localhost:8082/search/), try searching for `ski`.
+
+You should see search results. Note the URI for the first page of results:
+
+`/search/index?q=ski&search=Search`
+
+Scroll down and click **2** for the next page of results and note the URI adds `&p=[page_number]` for the pages (which are zero-indexed):
+
+`/search/index?q=ski&p=1`
+
+[http://localhost:8082/search/index?q=ski&p=1](http://localhost:8082/search/index?q=ski&p=1)
+
+## Simplify VTL in the Static `/search/` Page {#SimplifyVTL}
+
 Let's examine the behavior of the "static" search page which we are going to refactor.
 
-On [/search/](http://localhost:8080/search/) submit a search for "ski"
+On [/search/](http://localhost:8082/search/) once again submit a search for `ski`.
 
-The search results are paginated with 10 results page - scroll down to see links to the other pages of paginated results.
+You will see that search results are paginated with 10 results page. Scroll down to see links to the other pages of results. Also note the "By Type" and "Month Modified" search results aggregations.
 
-Also note the "By Type" and "Month Modified" search results aggregations.
+### Locate the "Site Search" VTL Code in dotCMS {#TheSearchForSearch}
 
-### Locate the "site search" VTL code in DotCMS
 To simplify the VTL for this example, let's remove the aggregations from the results page. 
 
-How do we find this code? In the back-end browse to
+How do we find this code? In the back-end browse to **Site -> Browser -> search**. Now double-click `index`, and then click the "Edit" tab.
 
-`Site -> Browser -> search -> double-click "index" -> click EDIT ->`
+Mouse over the "What are you looking for?" search form container and you will see a button  containing a pencil icon. Click on that to edit.
 
-`mouse over the "What are you looking for?" search form container -> click edit (pencil icon) ->`
+Now, click the `INFO` button to the right of the VTL File field to find its location: `/application/vtl/site-search/site-search.vtl`
 
-`click INFO next to the site-search.vtl file` to find it's location: `/application/vtl/site-search/site-search.vtl`
+Close the edit modals and return to the Site Browser. Now navigate to that file, and double click it to open.
 
-Close the edit modals to get back to the Site Browser to open this vtl file by double-clicking the file:
+Feel free to peruse the code to get a basic lay of the land. To summarize:
+- [Lines 1-126](https://github.com/yolabingo/dotcms-htmx/blob/e2d2dc774f2ac042048019393a68ef0306621a13/site-search.vtl#L1-L126) handle query-related tasks. 
+- [Lines 128-318](https://github.com/yolabingo/dotcms-htmx/blob/e2d2dc774f2ac042048019393a68ef0306621a13/site-search.vtl#L128-L318) generate HTML including the search form, search results, and search aggregation results.
 
-`application -> vtl -> site-search -> site-search.vtl`
+### Remove the Aggregations-Related Code {#SimplifySearchSurgery}
 
-Peruse the code to get a basic lay of the land.
-
-[Lines 1-126](https://github.com/yolabingo/dotcms-htmx/blob/e2d2dc774f2ac042048019393a68ef0306621a13/site-search.vtl#L1-L126) handle query-related tasks. 
-
-[Lines 128-318](https://github.com/yolabingo/dotcms-htmx/blob/e2d2dc774f2ac042048019393a68ef0306621a13/site-search.vtl#L128-L318) generate HTML including the search form, search results, and search aggregation results.
-
-### Remove the aggregations-related code from site-search.vtl
 To simplify the VTL for this example, we will remove the three blocks of code related to aggregations.
 
-Replace the current VTL code with this code: [/2-remove-search-aggregations/site-search.vtl](https://github.com/yolabingo/dotcms-htmx/blob/2-remove-search-aggregations/site-search.vtl)
+Replace the current VTL code with this code: [/2-remove-search-aggregations/site-search.vtl](https://raw.githubusercontent.com/yolabingo/dotcms-htmx/2-remove-search-aggregations/site-search.vtl)
 
-then click `Publish`
+Now click `Publish`.
 
-## Create /search/results "partial" Page
-We'll need to create a new "Page" on the site that returns "html over the wire" containing only the results of search queries - it must not include our header or footer files for "normal" HTML Pages.
+## Create `/search/results` "Partial" Page {#SearchResultsPartial}
 
-### Create search-results Container
+We'll need to create a new Page on the site that returns "html over the wire" containing only the results of search queries. This must not include our header or footer files for "normal" HTML Pages.
+
+### Create Search-Results Container {#SearchResultsPartialContainer}
+
 First, create a new Container.
 
-Go to `Site -> Containers -> "+" -> Add Container ->`
-```
-Title: search-results-htmx
-Code: paste in the site-search.vtl code
-```
-However this code must now be refactored - it need not generate the search form any more. It returns only the HTML for search results - basically a `<ul>` with an  `<li>` for each result. 
+Go to **Site -> Containers**. Click the Blue `+` button and then select `Add Container` and input the following:
+- Title: `search-results-htmx`
+- Code: (paste in the `site-search.vtl` code)
 
-Paste [this refactored version of our VTL](https://github.com/yolabingo/dotcms-htmx/blob/3-split-search-form-and-results/search-results-htmx.vtl) in the `Code` section.
+This code must now be refactored — it need not generate the search form any more. It returns only the HTML for search results — basically a `<ul>` with an  `<li>` for each result.
 
-then click "Save and Publish"
+Don't worry, we've got you covered: Just paste [this refactored version of our VTL](https://raw.githubusercontent.com/yolabingo/dotcms-htmx/3-split-search-form-and-results/search-results-htmx.vtl) in the "Code" section.
 
-### Create search-results Template
-Next, make a new Template that includes only this container. In the back-end
+Click `Save and Publish`.
 
-`Site -> Templates -> right-click "Blank" -> Copy -> double-click the copied "Blank - 1" -> EDIT` 
+### Create Search-Results Template {#SearchResultsPartialTemplate}
 
-Set 
-```
-Title: search-results-htmx` 
-Description: htmx "html-over-the-wire" search results
-```
-and Save.
+Next, make a new Template that includes only this container. In the back end, navigate to **Site -> Templates**. Right-click "Blank," and then pick Copy. Now double-click the copied "Blank - 1" and click the `EDIT` button beside the title.
 
-Then `Add a Container -> search-results-htmx - demo.dotcms.com` and Save.
+- Title: `search-results-htmx` 
+- Description: `htmx "html-over-the-wire" search results`
 
-Go back to Templates list to Publish the Template:
+Now `Save`. 
 
-`Site -> click Templates -> right-click "search-results-htmx" -> Publish`
+Then click the "Add a Container" dropdown, select the `search-results-htmx - demo.dotcms.com` item. Click the activated `Save` button.
 
-### Create search-results Page
-Create a new Page using this Template.
+Go back to Templates list to Publish the Template: **Site -> Templates**, then right-click `search-results-htmx` and select `Publish`.
 
-`Site -> Browser -> click on the "search" folder -> click "+" -> Page -> "type of Page = "Page" -> Select` and set:
-```
-Host of Folder: search
-Title: search-results
-Template: search-results-htmx (demo.dotcms.com)
-```
-click "Publish"
+### Create Search-Results Page {#SearchResultsPartialsPage}
 
-### Test search-results Page
-Try a couple tests
+Create a new Page using the new Template. Visit **Site -> Browser**. Click on the `search` folder, and then click the blue `+` button and select `Page` (type = "Page"). Set the following values:
+- Host or Folder: `search`
+- Title: `search-results`
+- Template: `search-results-htmx (demo.dotcms.com)`
 
-[http://localhost:8080/search/search-results?q=ski](http://localhost:8080/search/search-results?q=ski)
+Click `Publish`.
 
-[http://localhost:8080/search/search-results?q=ski&p=2](http://localhost:8080/search/search-results?q=ski&p=2)
+### Test Search-Results Page {#SearchResultsPartialsTest}
 
-Looks good! There is some pagination cruft to clean up but the functionality is there.
+Try out a couple of tests:
+- [http://localhost:8082/search/search-results?q=ski](http://localhost:8082/search/search-results?q=ski)
+- [http://localhost:8082/search/search-results?q=ski&p=2](http://localhost:8082/search/search-results?q=ski&p=2)
 
-### Final version of /search/search-results page
-[This final version of search-results-htmx.vtl](https://github.com/yolabingo/dotcms-htmx/blob/main/search-results-htmx.vtl) adds some finishing touches. Copy this VTL and replace the code in
+Looks good! There is some pagination cruft to clean up, but the functionality is there.
 
-`Site -> Containers -> double-click search-results-htmx -> Code -> Save and Publish` 
+### Final Version of `/search/search-results` Page {#SearchResultsPartialsFinal}
 
-## Refactor pagination logic to use htmx "Infinite Scroll"
-[htmx Infinte Scroll docs](https://htmx.org/examples/infinite-scroll/)
+[This final version of search-results-htmx.vtl](https://github.com/yolabingo/dotcms-htmx/blob/main/search-results-htmx.vtl) adds some finishing touches. Copy this VTL ([raw link](https://raw.githubusercontent.com/yolabingo/dotcms-htmx/main/search-results-htmx.vtl)) and replace the code: Navigate to **Site -> Containers**, double-click `search-results-htmx`, paste it into the "Code" field, and then `Save and Publish`.
 
-We can use the underlying pagination logic in the VTL with htmx infinte scroll. 
+## Refactor Pagination Logic With Htmx Infinite Scroll {#InfiniteScroll}
+
+> More detailed information on this functionality can be found in the [htmx Infinte Scroll documentation](https://htmx.org/examples/infinite-scroll/).
+
+We can use the underlying pagination logic in the VTL with htmx's "infinite scroll" capabilities.
 
 When last `<li>` in the search results is visible on the screen, htmx will fetch 10 more results and append them to the `<ul>`.
 
-This is achieved by adding htmx attributes to the final `<li>` on each page
+This is achieved simply by adding a few htmx attributes to the final `<li>` on each page:
+
 ```html
 <li hx-get="/search/search-results?q=ski&p=[next_page]"
     hx-trigger="revealed"
     hx-swap="afterend">
 ```
-## Refactor /search/ form to us htmx Active Search
-[htmx Active Search docs](https://htmx.org/examples/active-search/)
 
-Last step! Let's go back to
+## Refactor `/search/` Form to Use Htmx Active Search {#ActiveSearch}
 
-`Site -> Browser -> application -> vtl -> site-search -> site-search.vtl`
+> For more on this, see the [htmx Active Search docs](https://htmx.org/examples/active-search/).
 
-Replace the file contents with [this final version of site-search.vtl](https://github.com/yolabingo/dotcms-htmx/blob/main/site-search.vtl)
+We're at the finish line! 
 
-All that needs remain of the original code is the search form and associated markup. Then add htmx attributes and disable the default submit behavior. A stripped-down version demonstrating the htmx elemets is:
+Let's go back to **Site -> Browser**, then navigate to `application/vtl/site-search/site-search.vtl`. 
+
+Replace the file contents with [this final version of site-search.vtl](https://github.com/yolabingo/dotcms-htmx/blob/main/site-search.vtl).
+
+All that needs to remain of the original code is the search form and associated markup; from there, we add htmx attributes and disable the default submit behavior. A stripped-down version demonstrating the htmx elemets is:
+
 ```html
 <form action="javascript:void(0);">
     <input  name="q"
@@ -241,11 +241,11 @@ All that needs remain of the original code is the search form and associated mar
 <span id="search-results-htmx"></span>
 ```
 
-Go to [http://localhost:8080/search/](http://localhost:8080/search/) and try a few searches. For searches with more than 10 results like 
-```
-store
-ski
-blog
-```
-scroll down to see the infinite scroll behavior.
+Go to [http://localhost:8082/search/](http://localhost:8082/search/) and try a few searches. For searches with more than 10 results, such as:
+- `store`
+- `ski`
+- `blog`
 
+Now scroll down to see the "infinite scroll" behavior.
+
+As you can see, the actual code requirements of this were vastly simplified by htmx. If you prefer working in a pure HTML/CSS paradigm over working with Javascript — recognizing, of course, the minor irony of htmx being a Javascript library — you may find many more elegant little time-savers at your disposal with htmx and dotCMS.


### PR DESCRIPTION
Finished giving this a once-over. Some of it was just minor cleaning up, completing a sentence, adding em-dashes, etc. The bigger edits were more organizational — e.g., moving the Search Index build down past the htmx installation, as part of the example/project operations.

If it doesn't look like I made any obvious errors, I think next we can toss it over to Todd or Jason for their imprimatur before delivering it unto the blog. At the very least, it probably shouldn't need any further formatting!

Other note: I did that {#id} expanded markdown thing to the headings. GitHub doesn't respect it, but the doc site does, and I assume the blog, too. I guess we'll see.